### PR TITLE
Set  'redirect_uri' with app config callback URL

### DIFF
--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -523,7 +523,6 @@ class OAuthRemoteApp(object):
                 # state can be function for generate a random string
                 state = state()
 
-            session['%s_oauthredir' % self.name] = callback
             url = client.prepare_request_uri(
                 self.expand_url(self.authorize_url),
                 redirect_uri=callback,
@@ -623,12 +622,10 @@ class OAuthRemoteApp(object):
 
     def handle_oauth2_response(self):
         """Handles an oauth2 authorization response."""
-
         client = self.make_client()
         remote_args = {
             'code': request.args.get('code'),
             'client_secret': self.consumer_secret,
-            'redirect_uri': session.get('%s_oauthredir' % self.name)
         }
         log.debug('Prepare oauth2 remote args %r', remote_args)
         remote_args.update(self.access_token_params)
@@ -680,7 +677,6 @@ class OAuthRemoteApp(object):
 
         # free request token
         session.pop('%s_oauthtok' % self.name, None)
-        session.pop('%s_oauthredir' % self.name, None)
         return data
 
     def authorized_handler(self, f):

--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -637,6 +637,9 @@ class OAuthRemoteApp(object):
             oauth_redir_tuple[5:]
         )
 
+        # TODO: Just fetch from current_app.config?
+        log.debug('redirect_uri: {}'.format(oauth_redir))
+
         client = self.make_client()
         remote_args = {
             'code': request.args.get('code'),

--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -654,7 +654,7 @@ class OAuthRemoteApp(object):
                 self.access_token_method
             )
 
-        log.info('Resp: {}'.format(resp))
+        log.debug('Resp: {}'.format(resp))
 
         data = parse_response(resp, content, content_type=self.content_type)
         if resp.code not in (200, 201):

--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -19,11 +19,13 @@ from werkzeug import url_quote, url_decode, url_encode
 from werkzeug import parse_options_header, cached_property
 from .utils import to_bytes
 try:
-    from urlparse import urljoin
+    from urllib import urlencode
+    from urlparse import parse_qsl, urljoin, urlparse, urlunparse
     import urllib2 as http
 except ImportError:
     from urllib import request as http
     from urllib.parse import urljoin
+    from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 log = logging.getLogger('flask_oauthlib')
 
 
@@ -622,10 +624,24 @@ class OAuthRemoteApp(object):
 
     def handle_oauth2_response(self):
         """Handles an oauth2 authorization response."""
+
+        # Remove the 'code' argument from current URL
+        oauth_redir_tuple = urlparse(request.url)
+        query_args = [
+            arg_pair for arg_pair in parse_qsl(oauth_redir_tuple.query)
+            if arg_pair[0] != 'code'
+        ]
+        oauth_redir = urlunparse(
+            oauth_redir_tuple[0:4] +
+            (urlencode(query_args, doseq=True),) +
+            oauth_redir_tuple[5:]
+        )
+
         client = self.make_client()
         remote_args = {
             'code': request.args.get('code'),
             'client_secret': self.consumer_secret,
+            'redirect_uri': oauth_redir
         }
         log.debug('Prepare oauth2 remote args %r', remote_args)
         remote_args.update(self.access_token_params)

--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -19,13 +19,11 @@ from werkzeug import url_quote, url_decode, url_encode
 from werkzeug import parse_options_header, cached_property
 from .utils import to_bytes
 try:
-    from urllib import urlencode
-    from urlparse import parse_qsl, urljoin, urlparse, urlunparse
+    from urlparse import urljoin
     import urllib2 as http
 except ImportError:
     from urllib import request as http
     from urllib.parse import urljoin
-    from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 log = logging.getLogger('flask_oauthlib')
 
 

--- a/flask_oauthlib/client.py
+++ b/flask_oauthlib/client.py
@@ -654,6 +654,8 @@ class OAuthRemoteApp(object):
                 self.access_token_method
             )
 
+        log.info('Resp: {}'.format(resp))
+
         data = parse_response(resp, content, content_type=self.content_type)
         if resp.code not in (200, 201):
             raise OAuthException(


### PR DESCRIPTION
- Removes unsupported session handling for OAuth2.
- Set the `redirect_uri` to `app.config['OAUTH_CALLBACK_URL']`

LinkedIn requires the `redirect_uri` so we cannot simply remove it, as was done in [this solution](https://github.com/lepture/flask-oauthlib/pull/270)
